### PR TITLE
[HOTFIX] Memory leak due to low duration interval on cron refresh

### DIFF
--- a/src/server/refresh.js
+++ b/src/server/refresh.js
@@ -30,7 +30,7 @@ async function getAllContributorsInfo() {
     let organization = Config.organization
     let contributors = Config.contributors
 
-    interval = contributors.length // update interval
+    interval = contributors.length < 150 ? 150 : (contributors.length + 10) // update interval
 
     // Record time
     logBuffer.starttime = Date.now()


### PR DESCRIPTION
Earlier, on server start, the interval was set to a number of contributors due to which adding more number of contributors later without restarting the server for a long time would result in an increased number of requests within `delay` seconds. 
If the server started with no contributors in the config list, then it would have resulted in setting setInterval to `0 seconds`, resulting in a huge number of API calls to GitHub and memory leaks within few minutes of deployment. 

In this hotfix, the setInterval has been set to `150 * delay` seconds which can handle 150 - 200 users, post which, the server can crash after some days if not restarted.