### PR TITLE
[IMPROVE] Empty text field after adding contributor's name to list

### DIFF
--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -217,8 +217,8 @@ submit.addEventListener('click', () => {
             const addContributorButton = document.querySelector('.add-contributor-button.button')
 
             addContributorButton.addEventListener('click', () => {
-                const username = document.querySelector('.add-contributor').value
-
+                const usernameField = document.querySelector('.add-contributor')
+                const username = usernameField.value
                 if (username === '') {
                     msgError('your input is empty')
                     return
@@ -273,6 +273,7 @@ submit.addEventListener('click', () => {
 
                         $('tr')[insertPos].after(tr)
 
+                        usernameField.value = ''
                     } else {
                         msgError(message)
                     }


### PR DESCRIPTION
### Description:
After adding a contributor's name, the text field should automatically get emptied so that its easy to fill next contributor's name.

### Additional context
![add-contrib-name-after](https://user-images.githubusercontent.com/58601732/105578059-835e9b80-5da3-11eb-8548-2f8d017a81fb.gif)
