### PR TITLE
[FIX] HTTPS icon to be shown in the address bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
       <li class="nav-item text-nowrap">
         <a class="nav-link" id="github" href="https://github.com/RocketChat/GSoC-Contribution-Leaderboard-Node"
           target="_blank" rel="noopener noreferrer">
-          <img src="http://pluspng.com/img-png/github-octocat-vector-png--1600.png" height="45" width="45">
+          <img src="https://pluspng.com/img-png/github-octocat-vector-png--1600.png" height="45" width="45">
         </a>
       </li>
     </ul>


### PR DESCRIPTION
## Issue

The [GSOC LeaderBoard site](https://gsoc.rocket.chat/) shows **not secure** in the address bar.

![Not Secure Warning](https://user-images.githubusercontent.com/55396651/106395696-9e777e00-6429-11eb-8481-58468a17f25f.png)

This is due to the [Mixed Content Error](https://www.howtogeek.com/443032/what-is-mixed-content-and-why-is-chrome-blocking-it/). This can be seen if the **console is opened** up on the site.

![Console Error](https://user-images.githubusercontent.com/55396651/106395779-19d92f80-642a-11eb-804d-ddfdc594158b.png)

## Steps to Reproduce

1. Go to https://gsoc.rocket.chat/
2. Check the *icon* to the left of *gsoc.rocket.chat* in the address bar
3. It will show the not-secure icon
4. Open up the browser by pressing `Ctrl+Shift+I` and then navigate to the `console` tab
5. You will find the *Mixed Content* error in the logs

## Fix

This can be fixed by changing `http` to `https` in [/index.html#L19](https://github.com/RocketChat/Opensource-Contribution-Leaderboard/blob/master/index.html#L19)

## Further Comments

I had fixed the similar issue while we were developing the webapp for our club.


