### PR TITLE
fix: make adding contributors case-space-insensitive

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -245,7 +245,8 @@ const server = http.createServer( (req, res) => {
             } else {
                 const Config = jsonfile.readFileSync(configPath)
 
-                if (Config.contributors.includes(username)) {
+                if ((Config.contributors.map(contributor => contributor.toLowerCase()))
+                    .includes(username.toLowerCase().trim())) {
                     res.end(JSON.stringify({ message: `${username} aready exists` }))
                     return
                 }


### PR DESCRIPTION
Issue: Leaderboard was case-sensitive to usernames. Additionally, leading and trailing spaces while adding a contributor would be added as a separate contributor.
Fix: Lowercase and trim new usernames and compare against lowercased cached contributor list.