### PR TITLE
feat: exclude prs and issues labelled chore

### DIFF
--- a/src/server/util/API.js
+++ b/src/server/util/API.js
@@ -147,6 +147,12 @@ async function getContributorInfo(
         MergedPRsURL += `+repo:${organization}/${repository}`
         IssuesURL += `+repo:${organization}/${repository}`
     })
+    openPRsLink += '+-label:chore'
+    mergedPRsLink += '+-label:chore'
+    issuesLink += '+-label:chore'
+    OpenPRsURL += '+-label:chore'
+    MergedPRsURL += '+-label:chore'
+    IssuesURL += '+-label:chore'
     const openPRsNumber = await getOpenPRsNumber(OpenPRsURL)
     const mergedPRsNumber = await getMergedPRsNumber(MergedPRsURL)
     const issuesNumber = await getIssuesNumber(IssuesURL)


### PR DESCRIPTION
Excludes PRs and Issues labelled `chore` across all repositories from leaderboard rankings.