### PR TITLE
docs: add npm ERESOLVE fallback and lockfile note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,15 @@ npm run serve
 
 Frontend at http://localhost:8080.
 
+> **Note**
+> If `npm run add` fails with an `ERESOLVE` peer dependency error on newer npm versions, install the workspaces manually with legacy peer dependency resolution:
+> ```bash
+> npm install --legacy-peer-deps
+> npm --prefix src/server install --legacy-peer-deps
+> npm --prefix admin install --legacy-peer-deps
+> ```
+> Different Node.js, npm, or yarn versions can regenerate lockfiles even when you did not intend to change dependencies. Keep your local tool versions in mind when testing setup issues, and do not include `package-lock.json`, `yarn.lock`, `admin/package-lock.json`, or `admin/yarn.lock` changes in a PR unless your contribution is intentionally updating dependencies or install behavior.
+
 For production build:
 ```bash
 NODE_OPTIONS=--openssl-legacy-provider npm run build

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ cd dist/server
 node app.js
 ```
 
+If `npm run add` fails with an `ERESOLVE` peer dependency error on newer npm versions, install the workspaces manually with legacy peer dependency resolution:
+
+```bash
+npm install --legacy-peer-deps
+npm --prefix src/server install --legacy-peer-deps
+npm --prefix admin install --legacy-peer-deps
+```
+
 Open **http://localhost:8080** — you're done.
 
 ## Config Reference


### PR DESCRIPTION
## Summary

Add contributor-facing documentation for npm `ERESOLVE` setup failures and lockfile hygiene in local environments.

This is a standalone docs PR — no dependency changes, install script changes, or code refactors are mixed in.

## What changed

### README setup fallback
Added an alternative install path in `README.md` for contributors who hit `ERESOLVE` while running `npm run add` on newer npm versions.

Fallback commands:

```bash
npm install --legacy-peer-deps
npm --prefix src/server install --legacy-peer-deps
npm --prefix admin install --legacy-peer-deps
```

## Testing

npm run add:

<img width="717" height="377" alt="image" src="https://github.com/user-attachments/assets/0fda4d74-dbe4-4f0a-8ba4-7b432f2dc660" />

new command:

<img width="1447" height="387" alt="image" src="https://github.com/user-attachments/assets/9950fcc7-e61e-4753-8734-fd38c3aa7576" />


