### PR TITLE
fix: stop refresh cycle when GitHub rate limit is reached

### DIFF
--- a/src/server/refresh.js
+++ b/src/server/refresh.js
@@ -8,6 +8,7 @@ const dataBasePath = process.env.DATA_BASE_PATH || '../assets/data'
 const dataPath = process.env.DATA_PATH || '../assets/data/data.json'
 const logPath = process.env.LOG_PATH || '../assets/data/log.json'
 const configPath = process.env.CONFIG_PATH || './config.json'
+const rateLimitStopError = 'RATE_LIMIT_STOP'
 
 let interval = 150
 let dataBuffer = {}
@@ -36,30 +37,33 @@ async function getAllContributorsInfo() {
 
     // Record time
     logBuffer.starttime = Date.now()
+    API.resetRateLimitExceeded()
 
     Promise.mapSeries(contributors, async contributor => {
+        if (API.isRateLimitExceeded()) {
+            throw new Error(rateLimitStopError)
+        }
 
         await Promise.delay(delay * 1000)
 
-        API.getContributorInfo(process.env.ORGANIZATION, contributor, includedRepositories, startDate).then( res => {
-            Config = jsonfile.readFileSync(configPath) // update Config
-            delay = Config.delay // update delay
+        const res = await API.getContributorInfo(process.env.ORGANIZATION, contributor, includedRepositories, startDate)
+        Config = jsonfile.readFileSync(configPath) // update Config
+        delay = Config.delay // update delay
 
-            if (res.avatarUrl !== '' && res.issuesNumber !== -1 && res.mergedPRsNumber !== -1 && res.openPRsNumber != -1) {
+        if (res && res.avatarUrl !== '' && res.issuesNumber !== -1 && res.mergedPRsNumber !== -1 && res.openPRsNumber != -1) {
                 
-                dataBuffer = jsonfile.readFileSync(dataPath)
+            dataBuffer = jsonfile.readFileSync(dataPath)
 
-                if (Config.contributors.includes(contributor)) {
-                    dataBuffer[`${contributor}`] = res
-                    console.log(`${contributor} was updated: ${res.openPRsNumber} ${res.mergedPRsNumber} ${res.issuesNumber}`)
+            if (Config.contributors.includes(contributor)) {
+                dataBuffer[`${contributor}`] = res
+                console.log(`${contributor} was updated: ${res.openPRsNumber} ${res.mergedPRsNumber} ${res.issuesNumber}`)
 
-                    // Update contributors infomation
-                    jsonfile.writeFile(dataPath, dataBuffer, { spaces: 2 }, (err) => {
-                        if (err) console.error(err)
-                    })
-                }
+                // Update contributors infomation
+                jsonfile.writeFile(dataPath, dataBuffer, { spaces: 2 }, (err) => {
+                    if (err) console.error(err)
+                })
             }
-        })
+        }
 
         // Record time
         logBuffer.endtime = Date.now()
@@ -67,6 +71,13 @@ async function getAllContributorsInfo() {
         jsonfile.writeFile(logPath, logBuffer, { spaces: 2 }, (err) => {
             if (err) console.error(err)
         })
+    }).catch((err) => {
+        if (err.message === rateLimitStopError) {
+            console.log('[WARNING] Refresh cycle stopped because the GitHub API rate limit was reached.')
+            return
+        }
+
+        throw err
     })
 }
 

--- a/src/server/util/API.js
+++ b/src/server/util/API.js
@@ -3,6 +3,7 @@ const chalk = require('chalk')
 
 const BASEURL = 'https://github.com'
 const APIHOST = 'https://api.github.com'
+let rateLimitExceeded = false
 
 async function get(url, _authToken) {
     try {
@@ -37,6 +38,9 @@ async function get(url, _authToken) {
                 process.exit()
                 break
             default:
+                if (message.startsWith('API rate limit exceeded')) {
+                    rateLimitExceeded = true
+                }
                 console.log(chalk.yellow('[WARNING] ' + message))
             }
         } else {
@@ -243,4 +247,8 @@ module.exports = {
     checkRateLimit,
     getStats,
     getRanks,
+    isRateLimitExceeded: () => rateLimitExceeded,
+    resetRateLimitExceeded: () => {
+        rateLimitExceeded = false
+    },
 }


### PR DESCRIPTION
## Summary

Stops the current refresh cycle when the GitHub API rate limit is reached, instead of continuing to issue requests for the remaining contributors in the same run.

This keeps the server alive, but avoids wasting requests and producing repeated skip/warning noise after rate limiting has already been detected.

## Motivation

Once the GitHub API rate limit is exhausted, the current refresh loop continues processing contributors even though the remaining requests in that cycle are very likely to fail.

That leads to:
- unnecessary API calls
- repeated warning spam
- more skipped contributors
- confusing logs during local debugging and production operation

This change makes the refresh behavior more intentional: stop the current cycle early and wait for the next scheduled run.

## Changes (high level)

### `src/server/util/API.js`
- Adds a small internal `rateLimitExceeded` flag
- Sets that flag when GitHub returns an `API rate limit exceeded` message
- Exposes:
  - `isRateLimitExceeded()`
  - `resetRateLimitExceeded()`

### `src/server/refresh.js`
- Resets the rate-limit flag at the start of each refresh cycle
- Checks the flag before processing each contributor
- Stops the current cycle early once the flag is set
- Awaits each contributor fetch inside `Promise.mapSeries(...)` so requests complete sequentially and the stop behavior applies cleanly
- Logs:
  - `[WARNING] Refresh cycle stopped because the GitHub API rate limit was reached.`

## Why this is different from existing rate-limit logging

The existing API error handling logs the rate-limit message and returns from the individual request helper.

This change goes further by:
- tracking that the cycle has hit rate limiting
- stopping the remaining contributor processing for the current refresh run

## Tests

1. testing the functionality by forcing early stop before any contributor is pulled from github (not done in the fix)

<img width="1432" height="397" alt="image" src="https://github.com/user-attachments/assets/cd2ccb27-fcce-4cb8-bd92-69877ce353f4" />

process doesnt exit above, only execution stops(did'nt know what to do)

2. npm test

<img width="1155" height="378" alt="image" src="https://github.com/user-attachments/assets/1a51ad10-d493-4180-91aa-0399297e4b64" />

No automated tests were added for this change since enough e2e support is lacking.

**AI-assisted contribution disclosure - Mostly AI-generate**

## How to verify

```bash
NODE_OPTIONS=--openssl-legacy-provider npm run build
cd dist/server
node app.js


# run until GitHub rate limit is reached
# or in src/server/util/API.js add a rateLimitExceeded = true around below code
#           default:
#                rateLimitExceeded = true
#                if (message.startsWith('API rate limit exceeded')) {
#                    rateLimitExceeded = true
#               }
#                console.log(chalk.yellow('[WARNING] ' + message))
#            }
# Expected behavior:
# - GitHub rate-limit warning appears
# - "Refresh cycle stopped because the GitHub API rate limit was reached." is logged
# - remaining contributors in that cycle are not processed
